### PR TITLE
Segem training data no erosion

### DIFF
--- a/auxiliaryMethods/KLEEtoCNN/convertKleeTracingToLocalStack.m
+++ b/auxiliaryMethods/KLEEtoCNN/convertKleeTracingToLocalStack.m
@@ -33,12 +33,12 @@ for i=1:size( kn_tracing.contourList, 1 )
             pixel = sum(overlap(:));
             if pixel > 0
                 if pixel > 200
-                    figure('position', [1601 1 1920 1079]);
-                    subplot(1,3,1); imagesc(kn_inpoly); axis equal; axis off; title('Contour to add to cuurent slice');
-                    subplot(1,3,2); imagesc(kn_stack(:,:,kn_thisz)); axis equal; axis off; title('Current slice in stack');
-                    subplot(1,3,3); imagesc(overlap); axis equal; axis off; title('Overlap between 1&2');
-                    colormap(autoKLEE_colormap);
-                    warning(['Contours overlap in z-plane ' num2str(kn_thisz)  '! ' num2str(pixel) ' pixel labeled as extracellular']);
+                    %figure('position', [1601 1 1920 1079]);
+                    %subplot(1,3,1); imagesc(kn_inpoly); axis equal; axis off; title('Contour to add to cuurent slice');
+                    %subplot(1,3,2); imagesc(kn_stack(:,:,kn_thisz)); axis equal; axis off; title('Current slice in stack');
+                    %subplot(1,3,3); imagesc(overlap); axis equal; axis off; title('Overlap between 1&2');
+                    %colormap(autoKLEE_colormap);
+                    %warning(['Contours overlap in z-plane ' num2str(kn_thisz)  '! ' num2str(pixel) ' pixel labeled as extracellular']);
                 end
                 newPlane = kn_stack( :, :, kn_thisz ) + kn_inpoly;
                 newPlane(overlap) = 0;

--- a/auxiliaryMethods/KLEEtoCNN/convertKleeTracingToLocalStack.m
+++ b/auxiliaryMethods/KLEEtoCNN/convertKleeTracingToLocalStack.m
@@ -8,11 +8,11 @@ kn_tracing = changeToLocalTracing(kn_tracing, bboxTemp(:,1));
 % Preallocate stack matrix as unsigned integer
 kn_stack = zeros(bboxTemp(:,2)' - bboxTemp(:,1)' + [1 1 1], 'uint8' );
 % Create two grids which having the size of the bbox
-[kn_gridx, kn_gridy] = ndgrid( 1:bboxTemp(1,2)-bboxTemp(1,1)+1, 1:bboxTemp(2,2)-bboxTemp(2,1)+1 );  
+[kn_gridx, kn_gridy] = ndgrid( 1:bboxTemp(1,2)-bboxTemp(1,1)+1, 1:bboxTemp(2,2)-bboxTemp(2,1)+1 );
 
 for i=1:size( kn_tracing.contourList, 1 )
-        kn_thiscont = getClosedContour( kn_tracing.contours{i});   
-	
+        kn_thiscont = getClosedContour( kn_tracing.contours{i});
+
         % Create a 2 dimensional matrix with 0 and 1, every pixel inside a
         % traced cell is 1. kn_gridx and kn_gridy determine the size,
         % kn_thiscont gives the shape of the polygon. Multiply with the
@@ -20,11 +20,11 @@ for i=1:size( kn_tracing.contourList, 1 )
         % different integer values.
         kn_inpoly = uint8(inpolygon(kn_gridx,kn_gridy,kn_thiscont(:,1),kn_thiscont(:,2))...
         	*kn_tracing.contourList(i,3));
-        
+
         % Take the mean of the 3rd dimension of the tracing, to fit the
         % polygon into the stack.
         kn_thisz = nanmean(kn_thiscont(:, 3));
-        
+
         if kn_thisz < 1 || kn_thisz > bboxTemp(3,2)-bboxTemp(3,1)+1
             warning('Contour out of z-Range');
         else
@@ -33,7 +33,7 @@ for i=1:size( kn_tracing.contourList, 1 )
             pixel = sum(overlap(:));
             if pixel > 0
                 if pixel > 200
-                    figure('position', [1601 1 1920 1079]); 
+                    figure('position', [1601 1 1920 1079]);
                     subplot(1,3,1); imagesc(kn_inpoly); axis equal; axis off; title('Contour to add to cuurent slice');
                     subplot(1,3,2); imagesc(kn_stack(:,:,kn_thisz)); axis equal; axis off; title('Current slice in stack');
                     subplot(1,3,3); imagesc(overlap); axis equal; axis off; title('Overlap between 1&2');
@@ -49,13 +49,13 @@ for i=1:size( kn_tracing.contourList, 1 )
             % Fit the polygon into the stack by adding the polygon to the
             % (zero)-stack.
             kn_stack( :, :, kn_thisz ) = newPlane;
-        end      
+        end
 end
 
-stack = zeros(size(kn_stack), 'uint8');
+stack = zeros(size(kn_stack), 'uint32');
 for i=1:max(kn_stack(:))
 	bw = kn_stack == i;
-	bw = imerode(bw,ones(3,3,3));
+    %bw = imerode(bw,ones(3,3,3));
 	distBw = bwdist(bw) < 2 & ~bw;
 	stack(bw) = i;
 	setZero = distBw & stack ~= i;

--- a/auxiliaryMethods/KLEEtoCNN/generateCNNstacks.m
+++ b/auxiliaryMethods/KLEEtoCNN/generateCNNstacks.m
@@ -1,7 +1,7 @@
 function generateCNNstacks()
 
 settings.sourceDir = '/gaba/u/mberning/data/cortex/originalKLEE/';
-settings.targetDir.root = '/tmpscratch/webknossos/Connectomics_Department/2012-09-28_ex145_07x2_segEM_training_data/segmentationo_no_erosion/1/';
+settings.targetDir.root = '/tmpscratch/webknossos/Connectomics_Department/2012-09-28_ex145_07x2_segEM_training_data_no_erosion/segmentation/1/';
 settings.targetDir.backend = 'wkwrap';
 
 % Locate KLEE files from database & analyze
@@ -24,7 +24,7 @@ for i=1:length(stacks)
 end
 
 % Save all relevant meta information
-writeJson(fullfile(settings.targetDir, 'stacks.json'), stacks);
+writeJson(fullfile(settings.targetDir.root, 'stacks.json'), stacks);
 
 end
 

--- a/auxiliaryMethods/KLEEtoCNN/generateCNNstacks.m
+++ b/auxiliaryMethods/KLEEtoCNN/generateCNNstacks.m
@@ -1,22 +1,8 @@
 function generateCNNstacks()
-% Thres defines cutoff in distance transform of labeled cells (thereby defining extracellular border in untraced regions)
 
-settings.rawDir = '/zdata/manuel/data/cortex/2012-09-28_ex145_07x2_corrected/color/1/';
-settings.rawPrefix = '2012-09-28_ex145_07x2_corrected_mag1';
-settings.sourceDir = '/zdata/manuel/data/cortex/originalKLEE/';
-dateStr = datestr(clock, 30);
-settings.stackDir = ['/zdata/manuel/data/cortex/' dateStr  '/stackKLEE/'];
-settings.targetDir = ['/zdata/manuel/data/cortex/' dateStr  '/targetKLEE/'];
-settings.metaFile = ['/zdata/manuel/data/cortex/' dateStr '/parameter.mat'];
-settings.border = [50; 50; 25];
-
-% Make directories
-if ~exist(settings.stackDir)
-	mkdir(settings.stackDir);
-end
-if ~exist(settings.targetDir)
-	mkdir(settings.targetDir);
-end
+settings.sourceDir = '/gaba/u/mberning/data/cortex/originalKLEE/';
+settings.targetDir.root = '/tmpscratch/webknossos/Connectomics_Department/2012-09-28_ex145_07x2_segEM_training_data/segmentation/1/';
+settings.targetDir.backend = 'wkwrap';
 
 % Locate KLEE files from database & analyze
 files = dir([settings.sourceDir '3_15_*.mat']);
@@ -25,23 +11,20 @@ files2 = dir([settings.sourceDir '*corrected.mat']);
 stacksHD = selectFilesHD(files2);
 stacks = [stacksMR stacksHD];
 
+wkwInit('new', settings.targetDir.root, 32, 32, 'uint32', 1);
+
 for i=1:length(stacks)
 	display(['Processing stack ' num2str(i) '/' num2str(length(stacks))]);
 	load([settings.sourceDir stacks(i).filename]);
    	[stack, bbox] = convertKleeTracingToLocalStack( KLEE_savedTracing );
-	save([settings.stackDir num2str(stacks(i).taskID) '.mat'], 'stack');
-	stacks(i).stackFile = [settings.stackDir num2str(stacks(i).taskID) '.mat'];
-	target = xyzMaskIntraExtra(stack, 10);
-	bboxRaw = bbox([2 1 3],:) + [-settings.border settings.border];
-	raw = readKnossosRoi(settings.rawDir, settings.rawPrefix, bboxRaw);
-	save([settings.targetDir num2str(stacks(i).taskID) '.mat'], 'raw', 'target');
-	stacks(i).targetFile = [settings.targetDir num2str(stacks(i).taskID) '.mat'];
 	stacks(i).bbox = bbox;
-	stacks(i).bboxRaw = bboxRaw;
+    display(bbox);
+    % Save stack to original position in segmentation layer defined above as target dir in wkw format
+    saveSegDataGlobal(settings.targetDir, bbox(:,1), stack);
 end
 
 % Save all relevant meta information
-save(settings.metaFile, 'stacks', 'settings');
+writeJson(fullfile(settings.targetDir, 'stacks.json'), stacks);
 
 end
 

--- a/auxiliaryMethods/KLEEtoCNN/generateCNNstacks.m
+++ b/auxiliaryMethods/KLEEtoCNN/generateCNNstacks.m
@@ -1,7 +1,7 @@
 function generateCNNstacks()
 
 settings.sourceDir = '/gaba/u/mberning/data/cortex/originalKLEE/';
-settings.targetDir.root = '/tmpscratch/webknossos/Connectomics_Department/2012-09-28_ex145_07x2_segEM_training_data/segmentation/1/';
+settings.targetDir.root = '/tmpscratch/webknossos/Connectomics_Department/2012-09-28_ex145_07x2_segEM_training_data/segmentationo_no_erosion/1/';
 settings.targetDir.backend = 'wkwrap';
 
 % Locate KLEE files from database & analyze

--- a/auxiliaryMethods/KLEEtoCNN/selectFiles.m
+++ b/auxiliaryMethods/KLEEtoCNN/selectFiles.m
@@ -1,14 +1,30 @@
 function out = selectFiles(files)
-% ALmost obsolete function, for full version see manuelCode repo (only
-% makes sense in combination with braintracing DB @braintracing.de)
 
 for i=1:length(files)
-	param = regexp(files(i).name(1:end-4), '\_', 'split');
-	out(i).dataset = param{1};
-	out(i).taskID = str2double(param{2});
-	out(i).user = param{3};
-    out(i).filename = files(i).name;
+    param = regexp(files(i).name(1:end-4), '\_', 'split');
+    dataset(i) = str2num(param{1});
+    tasktype(i) = str2num(param{2});
+    task(i) = str2num(param{3});
+    user{i} = param{4};
+    upload(i) = str2num(param{5}(1:3));
 end
 
-end	
+if any(dataset ~= 3)
+    warning('Wrong dataset ID included');
+end
+
+if any(tasktype ~= 15)
+    warning('Wrong tasktype ID included');
+end
+
+uniqueTasks = unique(task);
+for i=1:length(uniqueTasks);
+    idxTasks = task == uniqueTasks(i);
+    uploads = upload .* idxTasks;
+    [lastUpload, idxMaxUpload] = max(uploads);
+    out(i).taskID = uniqueTasks(i);
+    out(i).lastUpload = lastUpload;
+    out(i).tracer = user{idxMaxUpload};
+    out(i).filename = files(idxMaxUpload).name;
+end
 


### PR DESCRIPTION
Not sure whether this should be merged but at least wanted to share.
Regenerate SegEM training data without erosion and store to wkwrap instead of .mat for easier visualization. Data can be inspected with webKnossos [here](https://webknossos.brain.mpg.de/annotations/Explorational/5d55c5a50100000a1efd1f62#2150,2144,2000,0,1.026).



Remaining ToDo could be to "globalize" the segmentation ids. Currently all 100^3 training cubes are numbered 1...N which makes the "highlight hovered cells" feature in wK a bit unintuitive.

See here for the list of training regions in json format:
`/tmpscratch/webknossos/Connectomics_Department/2012-09-28_ex145_07x2_segEM_training_data_no_erosion/segmentation/1/stacks.json`
and the webknossos dataset in that folder for the segmentation and raw data.
